### PR TITLE
Issue #93: Arguments for category logger were passed in correctly

### DIFF
--- a/category-style/src/typescript/main/impl/CategoryImpl.ts
+++ b/category-style/src/typescript/main/impl/CategoryImpl.ts
@@ -78,36 +78,36 @@ export class CategoryImpl implements Category {
   public trace(message: LogMessageType, ...args: unknown[]): void;
   public trace(message: LogMessageType, error: ExceptionType, ...args: unknown[]): void;
   public trace(message: LogMessageType, ...args: unknown[]): void {
-    this._logger.trace(message, args);
+    this._logger.trace(message, ...args);
   }
 
   public debug(message: LogMessageType, ...args: unknown[]): void;
   public debug(message: LogMessageType, error: ExceptionType, ...args: unknown[]): void;
   public debug(message: LogMessageType, ...args: unknown[]): void {
-    this._logger.debug(message, args);
+    this._logger.debug(message, ...args);
   }
 
   public info(message: LogMessageType, ...args: unknown[]): void;
   public info(message: LogMessageType, error: ExceptionType, ...args: unknown[]): void;
   public info(message: LogMessageType, ...args: unknown[]): void {
-    this._logger.info(message, args);
+    this._logger.info(message, ...args);
   }
 
   public warn(message: LogMessageType, ...args: unknown[]): void;
   public warn(message: LogMessageType, error: ExceptionType, ...args: unknown[]): void;
   public warn(message: LogMessageType, ...args: unknown[]): void {
-    this._logger.warn(message, args);
+    this._logger.warn(message, ...args);
   }
 
   public error(message: LogMessageType, ...args: unknown[]): void;
   public error(message: LogMessageType, error: ExceptionType, ...args: unknown[]): void;
   public error(message: LogMessageType, ...args: unknown[]): void {
-    this._logger.error(message, args);
+    this._logger.error(message, ...args);
   }
 
   public fatal(message: LogMessageType, ...args: unknown[]): void;
   public fatal(message: LogMessageType, error: ExceptionType, ...args: unknown[]): void;
   public fatal(message: LogMessageType, ...args: unknown[]): void {
-    this._logger.fatal(message, args);
+    this._logger.fatal(message, ...args);
   }
 }

--- a/category-style/src/typescript/test/TestCategoryProvider.spec.ts
+++ b/category-style/src/typescript/test/TestCategoryProvider.spec.ts
@@ -210,4 +210,22 @@ describe("Test CategoryProvider", () => {
     expect(child2.logLevel).toEqual(LogLevel.Info);
     expect(child2.runtimeSettings.channel).toEqual(channel2);
   });
+
+  test("Test passed arguments are correct", () => {
+    const channel = new $test.ArrayRawLogChannel();
+    const provider = CategoryProvider.createProvider("test", {
+      level: LogLevel.Debug,
+      channel,
+    });
+
+    const root = provider.getCategory("root");
+    root.debug("hello1");
+
+    root.debug("hello2", 10);
+    root.debug("hello3", { val: 100 });
+    root.debug(() => "hello4", "oops", { val: 100 }, { str: "abc" }, [10, 11]);
+
+    expect(channel.messages).toEqual(["hello1", "hello2", "hello3", "hello4"]);
+    expect(channel.rawMessages.map(msg => msg.args)).toEqual([undefined, [10], [{ val: 100 }], ["oops", { val: 100 }, { str: "abc" }, [10, 11]]]);
+  });
 });

--- a/core/src/typescript/main/core/api/CoreLogger.ts
+++ b/core/src/typescript/main/core/api/CoreLogger.ts
@@ -61,6 +61,7 @@ export interface CoreLogger {
    * log.debug("Hello", new Error("AnotherError"), "Some", "Random", "Arguments", [], 123);
    * ```
    * @param message Message
+   * @param error Error type (Error or lambda returning an Error)
    * @param args Optional arguments (note the first argument can be a (caught) Error which is treated as such then)
    */
   debug(message: LogMessageType, error: ExceptionType, ...args: unknown[]): void;

--- a/core/src/typescript/test/TestClasses.ts
+++ b/core/src/typescript/test/TestClasses.ts
@@ -44,6 +44,10 @@ export class ArrayRawLogChannel implements RawLogChannel {
     return this._buffer.length;
   }
 
+  public get rawMessages() {
+    return this._buffer;
+  }
+
   public clear() {
     this._buffer = [];
   }


### PR DESCRIPTION
Arguments didn't use the spread operator. This caused an extra array around them.

Added test to cover this.

Additionally minor doc fix (an argument was missing in CoreLogger).