### PR TITLE
Fixes issue where LogLevel.Trace is ignored on `createLogProvider`

### DIFF
--- a/log4ts-style/src/typescript/main/impl/Log4TSProviderService.ts
+++ b/log4ts-style/src/typescript/main/impl/Log4TSProviderService.ts
@@ -133,7 +133,7 @@ function mergeLog4TSConfigs(lhs: Log4TSConfig, rhs: Log4TSConfigOptional): Log4T
     channel: rhs.channel ? rhs.channel : lhs.channel,
     dateFormatter: rhs.dateFormatter ? rhs.dateFormatter : lhs.dateFormatter,
     groups: [] as Log4TSGroupConfig[], // Just so we can assign below
-    level: rhs.level ? rhs.level : lhs.level,
+    level: rhs.level !== undefined ? rhs.level : lhs.level,
   };
 
   /*


### PR DESCRIPTION
Because `LogLevel.Trace` is `0` the ternary check `rhs.level` will fail to apply `LogLevel.Trace` as the `level` and take the default `LogLevel.Error` instead. This fix checks explicitly for `undefined` instead.